### PR TITLE
Replace libs to vsCoreLibs

### DIFF
--- a/build-scripts/build.gradle.kts
+++ b/build-scripts/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 dependencies {
     // Мы хотим получать доступ к libs из наших convention плагинов, но гредл на текущий момент не умеет прокидывать
     // version catalogs. Поэтому используем костыль отсюда - https://github.com/gradle/gradle/issues/15383
-    implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
+    implementation(files(vsCoreLibs.javaClass.superclass.protectionDomain.codeSource.location))
 
-    implementation(libs.gradlePlugins.kotlin.core)
-    implementation(libs.gradlePlugins.android)
+    implementation(vsCoreLibs.gradlePlugins.kotlin.core)
+    implementation(vsCoreLibs.gradlePlugins.android)
 }

--- a/build-scripts/common-settings.gradle.kts
+++ b/build-scripts/common-settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
         gradlePluginPortal()
     }
     versionCatalogs {
-        create("libs") {
+        create("vsCoreLibs") {
             from(files("../libs.versions.toml"))
         }
     }

--- a/build-scripts/src/main/kotlin/ru/vladislavsumin/convention/kmp/common.gradle.kts
+++ b/build-scripts/src/main/kotlin/ru/vladislavsumin/convention/kmp/common.gradle.kts
@@ -1,6 +1,6 @@
 package ru.vladislavsumin.convention.kmp
 
-import ru.vladislavsumin.utils.libs
+import ru.vladislavsumin.utils.vsCoreLibs
 
 /**
  * Базовая настройка KMP.
@@ -19,7 +19,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation(libs.kotlin.coroutines.test)
+                implementation(vsCoreLibs.kotlin.coroutines.test)
             }
         }
     }

--- a/build-scripts/src/main/kotlin/ru/vladislavsumin/utils/VersionCatalogsUtils.kt
+++ b/build-scripts/src/main/kotlin/ru/vladislavsumin/utils/VersionCatalogsUtils.kt
@@ -1,10 +1,10 @@
 package ru.vladislavsumin.utils
 
-import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.accessors.dm.LibrariesForVsCoreLibs
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.the
 
 /**
  * Предоставляет доступ к каталогу версий внутри convention плагинов и прочего кода.
  */
-val Project.libs: LibrariesForLibs get() = rootProject.the()
+val Project.vsCoreLibs: LibrariesForVsCoreLibs get() = rootProject.the()

--- a/core/decompose/components/build.gradle.kts
+++ b/core/decompose/components/build.gradle.kts
@@ -9,11 +9,11 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(libs.kotlin.coroutines.core)
-            api(libs.decompose.core)
+            api(vsCoreLibs.kotlin.coroutines.core)
+            api(vsCoreLibs.decompose.core)
 
-            implementation(libs.kotlin.serialization.core)
-            implementation(libs.kotlin.serialization.json)
+            implementation(vsCoreLibs.kotlin.serialization.core)
+            implementation(vsCoreLibs.kotlin.serialization.json)
         }
     }
 }


### PR DESCRIPTION
Такая замена необходима для более простого подключения vs-core как композитного билда иначе велика вероятность коллизии для имени `libs`